### PR TITLE
BREAKING CHANGE: new API to import this module

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "node": ">=8.0.0"
   },
   "files": [
-    "/lib"
+    "./lib"
   ],
   "homepage": "https://github.com/mdapi-issues/listmetadata-standardvaluesettranslation-type",
   "keywords": [
@@ -35,7 +35,7 @@
     "MWE"
   ],
   "license": "MIT",
-  "main": "/lib/workaround.js",
+  "main": "./lib/workaround.js",
   "publishConfig": {
     "access": "public"
   },

--- a/test/issue.e2e-spec.ts
+++ b/test/issue.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { Org } from '@salesforce/core';
 import { expect } from 'chai';
-import listStandardValuSetTranslations from './issue';
+import { listStandardValuSetTranslations } from './issue';
 
 describe('listMetadata', function () {
   this.slow(5000);

--- a/test/issue.ts
+++ b/test/issue.ts
@@ -1,6 +1,6 @@
 import type { Connection, FileProperties } from 'jsforce';
 
-export default async function listStandardValuSetTranslations(
+export async function listStandardValuSetTranslations(
   conn: Connection
 ): Promise<Array<FileProperties>> {
   let fileProperties = await conn.metadata.list({


### PR DESCRIPTION
Make the workaround the primary entry point of this module.

Please migrate your code as follows:

```diff
- import { fixNilType } from '@mdapi-issues/listmetadata-standardvaluesettranslation-type/lib/workaround'
+ import { fixNilType } from '@mdapi-issues/listmetadata-standardvaluesettranslation-type'
```